### PR TITLE
Добавлено поле cover_url в Film

### DIFF
--- a/kinopoisk_unofficial/model/film.py
+++ b/kinopoisk_unofficial/model/film.py
@@ -40,6 +40,7 @@ class Film:
     genres: List[Genre]
     start_year: Union[int, None]
     end_year: Union[int, None]
+    cover_url: Optional[str] = None
     web_url: Optional[str] = None
     slogan: Optional[str] = None
     description: Optional[str] = None


### PR DESCRIPTION
Небольшое обновление
Добавлено поле coverUrl в [https://kinopoiskapiunofficial.tech/documentation/api/#/films/get_api_v2_2_films__id_](https://kinopoiskapiunofficial.tech/documentation/api/#/films/get_api_v2_2_films__id_)

Частично закрывает #5